### PR TITLE
Add drat folder to the valid repos

### DIFF
--- a/inst/activate.R
+++ b/inst/activate.R
@@ -9,7 +9,7 @@ local({
     stop(paste(msg, collapse = "\n"))
   }
 
-  nomad_url <- paste0("file:///", getwd())
+  nomad_url <- paste0("file:///", c(getwd(), file.path(getwd(), "drat")))
   nomad_url <- sub("file:////", "file:///", nomad_url)
   options(repos = nomad_url,
           nomad.location = getwd())


### PR DESCRIPTION
I had noticed that packages listed in the `drat/` folder were not necessarily listed in the `src/` folder, preventing their installation. If I added the `drat/` folder to the valid repos, then these packages would install correctly.