### PR TITLE
quickfix for weird RStudio thing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,14 +4,18 @@ Version: 0.0.1
 Authors@R: c(person("Rich", "FitzJohn", email = "rich.fitzjohn@gmail.com",
                     role = c("aut", "cre")),
              person("Thibaut", "Jombart", email = "thibautjombart@gmail.com",
-                    role = c("aut")))
+                    role = c("aut")),
+             person("Zhian N.", "Kamvar", email = "zkamvar@gmail.com",
+                    role = c("ctb")),
+             )
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Collects together all the bits required to easily install
   packages from R in situations with limited internet.
 License: MIT + file LICENSE
 Imports:
   provisionr (>= 0.1.5),
-  yaml
+  yaml,
+  utils
 Remotes:
   richfitz/provisionr
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Authors@R: c(person("Rich", "FitzJohn", email = "rich.fitzjohn@gmail.com",
                     role = c("aut")),
              person("Zhian N.", "Kamvar", email = "zkamvar@gmail.com",
                     role = c("ctb")),
+             NULL
              )
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Collects together all the bits required to easily install

--- a/R/build.R
+++ b/R/build.R
@@ -17,7 +17,7 @@ build <- function(ref, dest, progress = NULL) {
   dir.create(tmp, FALSE, TRUE)
   file <- sprintf("%s-%s.zip", dat$username, dat$repo)
   provisionr::download_files(url_zipball, tmp, dest_file = file, count = FALSE)
-  unzip(file.path(tmp, file), exdir = tmp)
+  utils::unzip(file.path(tmp, file), exdir = tmp)
   path <- setdiff(dir(tmp), file)
   stopifnot(length(path) == 1L)
   path <- file.path(tmp, path)

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -8,9 +8,10 @@ download_rstudio <- function(path, target = "windows", progress = TRUE) {
   res <- try({
     provisionr::download_files(url, path, labels = names(url),
                                count = length(url) > 1L, progress = progress)
-  })
+  }, silent = TRUE)
   if (inherits(res, "try-error")) {
-    url <- gsub("-1.exe", ".exe", res)
+    url <- gsub("-1\\.([a-z]{3})", ".\\1", url)
+    print(url)
     provisionr::download_files(url, path, labels = names(url),
                                count = length(url) > 1L, progress = progress)
 
@@ -18,22 +19,22 @@ download_rstudio <- function(path, target = "windows", progress = TRUE) {
 }
 
 url_rstudio <- function(target, version = NULL) {
-  base <- "https://download1.rstudio.org"
+  base <- "https://download1.rstudio.org/desktop"
   loc_linux <- c(
                  ## ubuntu32 = "rstudio-%s-i386.deb",
-                 ubuntu64 = "rstudio-%s-amd64.deb",
+                 ubuntu64 = "%s/rstudio-%s-amd64.deb",
                  ## fedora32 = "rstudio-%s-i686.rpm",
-                 fedora64 = "rstudio-%s-x86_64.rpm")
-  loc <- c(windows = "RStudio-%s.exe",
-           macosx = "RStudio-%s.dmg",
+                 fedora64 = "%s/rstudio-%s-x86_64.rpm")
+  loc <- c(windows = "windows/RStudio-%s.exe",
+           macos   = "macos/RStudio-%s.dmg",
            loc_linux)
 
   if (identical(target, "ALL")) {
     target <- names(loc)
   } else {
-    is_mac <- grepl("^macosx", target)
+    is_mac <- grepl("^macos", target)
     if (any(is_mac)) {
-      target <- c(target[!is_mac], "macosx")
+      target <- c(target[!is_mac], "macos")
     }
     is_linux <- target == "linux"
     if (any(is_linux)) {

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -19,6 +19,14 @@ download_rstudio <- function(path, target = "windows", progress = TRUE) {
 }
 
 url_rstudio <- function(target, version = NULL) {
+  # Note to future nomads:
+  #
+  # You've got 404
+  # Dispare no more and seek out
+  # a new URL
+  #
+  # Just use the source, $luke
+  # https://www.rstudio.com/products/rstudio/download/#download
   base <- "https://download1.rstudio.org/desktop"
   loc_linux <- c(
                  ## ubuntu32 = "rstudio-%s-i386.deb",

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -5,17 +5,25 @@
 download_rstudio <- function(path, target = "windows", progress = TRUE) {
   dir.create(path, FALSE, TRUE)
   url <- url_rstudio(target)
-  provisionr::download_files(url, path, labels = names(url),
-                             count = length(url) > 1L, progress = progress)
+  res <- try({
+    provisionr::download_files(url, path, labels = names(url),
+                               count = length(url) > 1L, progress = progress)
+  })
+  if (inherits(res, "try-error")) {
+    url <- gsub("-1.exe", ".exe", res)
+    provisionr::download_files(url, path, labels = names(url),
+                               count = length(url) > 1L, progress = progress)
+
+  }
 }
 
 url_rstudio <- function(target, version = NULL) {
   base <- "https://download1.rstudio.org"
   loc_linux <- c(
-    ## ubuntu32 = "rstudio-%s-i386.deb",
-    ubuntu64 = "rstudio-%s-amd64.deb",
-    ## fedora32 = "rstudio-%s-i686.rpm",
-    fedora64 = "rstudio-%s-x86_64.rpm")
+                 ## ubuntu32 = "rstudio-%s-i386.deb",
+                 ubuntu64 = "rstudio-%s-amd64.deb",
+                 ## fedora32 = "rstudio-%s-i686.rpm",
+                 fedora64 = "rstudio-%s-x86_64.rpm")
   loc <- c(windows = "RStudio-%s.exe",
            macosx = "RStudio-%s.dmg",
            loc_linux)

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -5,18 +5,18 @@
 download_rstudio <- function(path, target = "windows", progress = TRUE) {
   dir.create(path, FALSE, TRUE)
   url <- url_rstudio(target)
-  res <- try({
-    provisionr::download_files(url, path, labels = names(url),
-                               count = length(url) > 1L, progress = progress)
-  }, silent = TRUE)
-  if (inherits(res, "try-error")) {
-    url <- gsub("-1\\.([a-z]{3})", ".\\1", url)
-    print(url)
-    provisionr::download_files(url, path, labels = names(url),
-                               count = length(url) > 1L, progress = progress)
-
-  }
+  provisionr::download_files(url, path, labels = names(url),
+                             count = length(url) > 1L, progress = progress)
 }
+# "https://download1.rstudio.org/desktop/windows/RStudio-1.2.1335.exe"
+# "https://download1.rstudio.org/desktop/macos/RStudio-1.2.1335.dmg"
+# "https://download1.rstudio.org/desktop/trusty/amd64/rstudio-1.2.1335-amd64.deb"
+# "https://download1.rstudio.org/desktop/xenial/amd64/rstudio-1.2.1335-amd64.deb"
+# "https://download1.rstudio.org/desktop/bionic/amd64/rstudio-1.2.1335-amd64.deb"
+# "https://download1.rstudio.org/desktop/centos7/x86_64/rstudio-1.2.1335-x86_64.rpm"
+# "https://download1.rstudio.org/desktop/debian9/x86_64/rstudio-1.2.1335-amd64.deb"
+# "https://download1.rstudio.org/desktop/opensuse15/x86_64/rstudio-1.2.1335-x86_64.rpm"
+# "https://download1.rstudio.org/desktop/opensuse/x86_64/rstudio-1.2.1335-x86_64.rpm"
 
 url_rstudio <- function(target, version = NULL) {
   # Note to future nomads:
@@ -29,10 +29,15 @@ url_rstudio <- function(target, version = NULL) {
   # https://www.rstudio.com/products/rstudio/download/#download
   base <- "https://download1.rstudio.org/desktop"
   loc_linux <- c(
-                 ## ubuntu32 = "rstudio-%s-i386.deb",
-                 ubuntu64 = "trusty/rstudio-%s-amd64.deb",
-                 ## fedora32 = "rstudio-%s-i686.rpm",
-                 fedora64 = "centos7/x86_64/rstudio-%s-x86_64.rpm")
+                 trusty     = "trusty/amd64/rstudio-%s-amd64.deb",
+                 xenial     = "xenial/amd64/rstudio-%s-amd64.deb",
+                 bionic     = "bionic/amd64/rstudio-%s-amd64.deb",
+                 centos7    = "centos7/x86_64/rstudio-%s-x86_64.rpm",
+                 debian9    = "debian9/x86_64/rstudio-%s-x86_64.rpm",
+                 opensuse15 = "opensuse15/x86_64/rstudio-%s-x86_64.rpm",
+                 opensuse   = "opensuse/x86_64/rstudio-%s-x86_64.rpm",
+                 NULL
+                )
   loc <- c(windows = "windows/RStudio-%s.exe",
            macos   = "macos/RStudio-%s.dmg",
            loc_linux)
@@ -58,6 +63,8 @@ url_rstudio <- function(target, version = NULL) {
   if (is.null(version)) {
     version <- readLines("https://download1.rstudio.org/current.ver",
                          warn = FALSE)
+    # remove extra BS
+    version <- gsub("-1$", "", version)
   }
 
   ret <- file.path(base, sprintf(loc[target], version))

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -30,9 +30,9 @@ url_rstudio <- function(target, version = NULL) {
   base <- "https://download1.rstudio.org/desktop"
   loc_linux <- c(
                  ## ubuntu32 = "rstudio-%s-i386.deb",
-                 ubuntu64 = "%s/rstudio-%s-amd64.deb",
+                 ubuntu64 = "trusty/rstudio-%s-amd64.deb",
                  ## fedora32 = "rstudio-%s-i686.rpm",
-                 fedora64 = "%s/rstudio-%s-x86_64.rpm")
+                 fedora64 = "centos7/x86_64/rstudio-%s-x86_64.rpm")
   loc <- c(windows = "windows/RStudio-%s.exe",
            macos   = "macos/RStudio-%s.dmg",
            loc_linux)

--- a/tests/testthat/test-rstudio.R
+++ b/tests/testthat/test-rstudio.R
@@ -7,12 +7,14 @@ test_that("url_rstudio", {
 })
 
 test_that("url_rstudio: target all", {
+  skip("FIXME: RStudio changed a bunch of things")
   u <- url_rstudio("ALL", "1.2.3")
   expect_equal(sort(names(u)),
                sort(c("windows", "macosx", "ubuntu64", "fedora64")))
 })
 
 test_that("url_rstudio: linux", {
+  skip("FIXME: RStudio changed a bunch of things")
   u <- url_rstudio("linux", "1.2.3")
   expect_equal(sort(names(u)),
                sort(c("ubuntu64", "fedora64")))

--- a/tests/testthat/test-rstudio.R
+++ b/tests/testthat/test-rstudio.R
@@ -7,17 +7,17 @@ test_that("url_rstudio", {
 })
 
 test_that("url_rstudio: target all", {
-  skip("FIXME: RStudio changed a bunch of things")
   u <- url_rstudio("ALL", "1.2.3")
-  expect_equal(sort(names(u)),
-               sort(c("windows", "macosx", "ubuntu64", "fedora64")))
+  expect_setequal(names(u), 
+                  c("windows", "macos", "trusty", "xenial", "bionic",
+                    "centos7", "debian9", "opensuse15", "opensuse"))
 })
 
 test_that("url_rstudio: linux", {
-  skip("FIXME: RStudio changed a bunch of things")
   u <- url_rstudio("linux", "1.2.3")
-  expect_equal(sort(names(u)),
-               sort(c("ubuntu64", "fedora64")))
+  expect_setequal(names(u),
+                  c("trusty", "xenial", "bionic", "centos7", "debian9",
+                    "opensuse15", "opensuse"))
 })
 
 test_that("url_rstudio: target invalid", {


### PR DESCRIPTION
This changes the base url to `https://download1.rstudio.org/desktop/<platform>/RStudio-<version>.<ext>`

and attempts to remove any `-1` before the ext.

https://github.com/rstudio/rstudio/issues/4639