### PR TITLE
remove RStudio develpatch version number in generic manner

### DIFF
--- a/R/nomad.R
+++ b/R/nomad.R
@@ -13,7 +13,7 @@
 ##'
 ##' @export
 pack <- function(path, progress = NULL) {
-  if (!file.exists(path) || !file.info(path)$isdir) {
+  if (!file.exists(path) || !all(file.info(path)$isdir)) {
     stop("'path' must be an existing directory")
   }
   cfg <- nomad_prepare(nomad_config(path))

--- a/R/nomad.R
+++ b/R/nomad.R
@@ -13,12 +13,12 @@
 ##'
 ##' @export
 pack <- function(path, progress = NULL) {
-  if (!file.exists(path) || !all(file.info(path)$isdir)) {
+  if (!file.exists(path) || !file.info(path)$isdir) {
     stop("'path' must be an existing directory")
   }
   cfg <- nomad_prepare(nomad_config(path))
 
-  target_includes_windows <- cfg$target %in% c("ALL", "windows")
+  target_includes_windows <- any(cfg$target %in% c("ALL", "windows"))
 
   ## Then we start the fun part:
   message("nomad: cran")

--- a/R/rstudio.R
+++ b/R/rstudio.R
@@ -64,7 +64,7 @@ url_rstudio <- function(target, version = NULL) {
     version <- readLines("https://download1.rstudio.org/current.ver",
                          warn = FALSE)
     # remove extra BS
-    version <- gsub("-1$", "", version)
+    version <- gsub("-\\d+$", "", version)
   }
 
   ret <- file.path(base, sprintf(loc[target], version))


### PR DESCRIPTION
I was getting an error because we were trying to fetch an RStudio
verison that was incorrect because RStudio likes to publish version
numbers such as

1.2.5001-1

but the installers to be downloaded would not have the -1 suffix.,

In my madness last time I fixed this (#18), I had assumed that the final
number would always be "1", but instead found out that it can be
anything, really. This will fix that issue.


This additionally fixes a length coercion issue (see 43b2999)